### PR TITLE
Fix firefox and brave not working

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,13 @@
+import { isChrome } from '~utils/extension';
+
+// Both brave and firefox for some reason need this extension reload,
+// If this isn't done, they will never load properly and will fail updateDynamicRules()
+if (isChrome()) {
+  chrome.runtime.onStartup.addListener(() => {
+    chrome.runtime.reload();
+  });
+} else {
+  browser.runtime.onStartup.addListener(() => {
+    browser.runtime.reload();
+  });
+}

--- a/src/background/messages/makeRequest.ts
+++ b/src/background/messages/makeRequest.ts
@@ -49,19 +49,20 @@ const mapBodyToFetchBody = (body: Request['body'], bodyType: Request['bodyType']
 
 const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (req, res) => {
   try {
+    const url = makeFullUrl(req.body.url, req.body);
     await assertDomainWhitelist(req.sender.tab.url);
 
     if (req.body.headers['User-Agent']) {
       await setDynamicRules({
         ruleId: MAKE_REQUEST_DYNAMIC_RULE,
-        targetDomains: [new URL(req.body.url).hostname],
+        targetDomains: [new URL(url).hostname],
         requestHeaders: {
           'User-Agent': req.body.headers['User-Agent'],
         },
       });
     }
 
-    const response = await fetch(makeFullUrl(req.body.url, req.body), {
+    const response = await fetch(url, {
       method: req.body.method,
       headers: req.body.headers,
       body: mapBodyToFetchBody(req.body.body, req.body.bodyType),
@@ -80,6 +81,7 @@ const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (r
       },
     });
   } catch (err) {
+    console.error('failed request', err);
     res.send({
       success: false,
       error: err.message,


### PR DESCRIPTION
resolves https://github.com/movie-web/movie-web/issues/846

changes:
 - Add background script to reload on extension load. This somehow fixes firefox and brave.
 - Add logging for failed fetch requests
 - Use full url user agent rule targeting.
 
I'm guessing the reload is needed because the extension is booted faster than the host app. So the communcation pathways aren't setup yet and never will be.


