### PR TITLE
fix headers not being applied to request

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "manifest": {
     "permissions": [
       "declarativeNetRequest",
-      "tabs"
+      "tabs",
+      "cookies"
     ],
     "host_permissions": [
       "<all_urls>",

--- a/src/background/messages/makeRequest.ts
+++ b/src/background/messages/makeRequest.ts
@@ -52,13 +52,11 @@ const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (r
     const url = makeFullUrl(req.body.url, req.body);
     await assertDomainWhitelist(req.sender.tab.url);
 
-    if (req.body.headers['User-Agent']) {
+    if (Object.keys(req.body.headers).length > 0) {
       await setDynamicRules({
         ruleId: MAKE_REQUEST_DYNAMIC_RULE,
         targetDomains: [new URL(url).hostname],
-        requestHeaders: {
-          'User-Agent': req.body.headers['User-Agent'],
-        },
+        requestHeaders: req.body.headers,
       });
     }
 

--- a/src/background/messages/makeRequest.ts
+++ b/src/background/messages/makeRequest.ts
@@ -79,7 +79,7 @@ const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (r
         statusCode: response.status,
         headers: {
           ...Object.fromEntries(response.headers.entries()),
-          'Set-Cookie': cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; '),
+          'Set-Cookie': cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join(', '),
         },
         body,
         finalUrl: response.url,

--- a/src/background/messages/makeRequest.ts
+++ b/src/background/messages/makeRequest.ts
@@ -69,11 +69,18 @@ const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (r
     const contentType = response.headers.get('content-type');
     const body = contentType?.includes('application/json') ? await response.json() : await response.text();
 
+    const cookies = await (chrome || browser).cookies.getAll({
+      url: response.url,
+    });
+
     res.send({
       success: true,
       response: {
         statusCode: response.status,
-        headers: Object.fromEntries(response.headers.entries()), // Headers object isn't serializable
+        headers: {
+          ...Object.fromEntries(response.headers.entries()),
+          'Set-Cookie': cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; '),
+        },
         body,
         finalUrl: response.url,
       },

--- a/src/utils/declarativeNetRequest.ts
+++ b/src/utils/declarativeNetRequest.ts
@@ -56,6 +56,11 @@ export const setDynamicRules = async (body: DynamicRule) => {
                 operation: chrome.declarativeNetRequest.HeaderOperation.SET,
                 value: '*',
               },
+              {
+                header: 'Access-Control-Allow-Credentials',
+                operation: chrome.declarativeNetRequest.HeaderOperation.SET,
+                value: 'true',
+              },
               ...mapHeadersToDeclarativeNetRequestHeaders(
                 body.responseHeaders ?? {},
                 chrome.declarativeNetRequest.HeaderOperation.SET,
@@ -98,6 +103,11 @@ export const setDynamicRules = async (body: DynamicRule) => {
                 header: 'Access-Control-Allow-Headers',
                 operation: 'set',
                 value: '*',
+              },
+              {
+                header: 'Access-Control-Allow-Credentials',
+                operation: 'set',
+                value: 'true',
               },
               ...mapHeadersToDeclarativeNetRequestHeaders(body.responseHeaders ?? {}, 'set'),
             ],


### PR DESCRIPTION
This pull request resolves movie-web/movie-web#876

FYI this doesn't fix goojara, since there also seems to be an issue related to the second cookie being retrieved. The first cookie seems to be applied to the request. But in the second request the server does not return a cookie in the 'Set-Cookie' header.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
