### PR TITLE
always create dynamic rule for fetch request

### DIFF
--- a/src/background/messages/makeRequest.ts
+++ b/src/background/messages/makeRequest.ts
@@ -52,13 +52,11 @@ const handler: PlasmoMessaging.MessageHandler<Request, Response<any>> = async (r
     const url = makeFullUrl(req.body.url, req.body);
     await assertDomainWhitelist(req.sender.tab.url);
 
-    if (Object.keys(req.body.headers).length > 0) {
-      await setDynamicRules({
-        ruleId: MAKE_REQUEST_DYNAMIC_RULE,
-        targetDomains: [new URL(url).hostname],
-        requestHeaders: req.body.headers,
-      });
-    }
+    await setDynamicRules({
+      ruleId: MAKE_REQUEST_DYNAMIC_RULE,
+      targetDomains: [new URL(url).hostname],
+      requestHeaders: req.body.headers,
+    });
 
     const response = await fetch(url, {
       method: req.body.method,


### PR DESCRIPTION
This pull request resolves movie-web/movie-web#904

makeRequest should always append dynamic rules to bypass CORS even if no headers are added.

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
