### PR TITLE
fix ts error, fix styling on PermissionRequest

### DIFF
--- a/src/hooks/useDomainWhitelist.ts
+++ b/src/hooks/useDomainWhitelist.ts
@@ -23,9 +23,9 @@ export function useDomainWhitelist() {
   };
 }
 
-export function useToggleWhitelistDomain(domain: string) {
+export function useToggleWhitelistDomain(domain: string | null) {
   const { domainWhitelist, addDomain, removeDomain } = useDomainWhitelist();
-  const isWhitelisted = domainWhitelist.includes(domain);
+  const isWhitelisted = domainWhitelist.includes(domain ?? '');
   const { grantPermission } = usePermission();
   const iconPath = (chrome || browser).runtime.getURL(isWhitelisted ? 'assets/active.png' : 'assets/inactive.png');
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -28,7 +28,7 @@ function IndexPopup() {
   ) : (
     <Frame>
       <div className="popup">
-        {page === 'toggle' ? <ToggleButton active={isWhitelisted} onClick={toggle} domain={domain} /> : null}
+        {page === 'toggle' && domain ? <ToggleButton active={isWhitelisted} onClick={toggle} domain={domain} /> : null}
         {page === 'disabled' ? <DisabledScreen /> : null}
         <BottomLabel />
       </div>

--- a/src/tabs/PermissionRequest.css
+++ b/src/tabs/PermissionRequest.css
@@ -10,6 +10,10 @@ body {
   padding-bottom: 50px;
 }
 
+#__plasmo {
+  height: unset;
+}
+
 .permission-request.container {
   width: 90%;
   margin: 100px auto;


### PR DESCRIPTION
This pull request resolves movie-web/movie-web#1047

For reasons I can't explain, PermissionGrant.css is injected into the DOM on the PermissionRequest page, but not the other way. So the __plasmo styling of PermissionGrant was being applied to the Request page. So on the Request page I unset the height that is set on the PermissionGrant page 😅 

There was also 1 strict typescript error left in the code

 - [x] I have read and agreed to the [code of conduct](https://github.com/movie-web/movie-web/blob/dev/.github/CODE_OF_CONDUCT.md).
 - [x] I have read and complied with the [contributing guidelines](https://github.com/movie-web/movie-web/blob/dev/.github/CONTRIBUTING.md).
 - [x] What I'm implementing was assigned to me and is an [approved issue](https://github.com/movie-web/movie-web/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved). For reference, please take a look at our [GitHub projects](https://github.com/movie-web/movie-web/projects).
 - [x] I have tested all of my changes.
